### PR TITLE
Refactor again to be a wsgi usable package

### DIFF
--- a/standup_webapp/__init__.py
+++ b/standup_webapp/__init__.py
@@ -1,2 +1,6 @@
-from standup_webapp.standup import app
-app.run()
+from flask import Flask
+
+app = Flask(__name__)
+app.config.from_pyfile('/etc/standup/standup.cfg', silent=True)
+
+import standup_webapp.views

--- a/standup_webapp/views.py
+++ b/standup_webapp/views.py
@@ -1,10 +1,8 @@
+from standup_webapp import app
+
 import sqlite3
 from datetime import date, timedelta, datetime
-from flask import Flask, g, render_template, request, redirect, url_for
-
-app = Flask(__name__)
-app.config.from_pyfile('/etc/standup/standup.cfg', silent=True)
-
+from flask import g, render_template, request, redirect, url_for
 
 @app.route('/')
 def index():

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,4 @@
-from standup_webapp import app
+from standup_webapp import app as application
 
 if __name__ == "__main__":
-    app.run()
+    application.run()


### PR DESCRIPTION
The previous refactor actually had a few things that meant it wasn't
usable via uwsgi. This is based on the following from Flask's
documentation:
http://flask.pocoo.org/docs/0.12/patterns/packages/#larger-applications

as well as changes to the wsgi entrypoint according to this doc:
http://flask.pocoo.org/docs/0.12/deploying/mod_wsgi/#creating-a-wsgi-file

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>